### PR TITLE
update makefile for test egrep

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,11 +22,11 @@ jobs:
         case "${TARGET}" in
           linux-amd64-e2e)
             PASSES='build release e2e' MANUAL_VER=v3.4.7 CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
-            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
+            ! egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
             ;;
           linux-386-e2e)
             GOARCH=386 PASSES='build e2e' CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
-            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
+            ! egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
             ;;
           *)
             echo "Failed to find target"

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -21,7 +21,7 @@ jobs:
         case "${TARGET}" in
           linux-amd64-grpcproxy)
             PASSES='build grpcproxy'  CPU='4' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
-            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
+            ! egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
             ;;
           *)
             echo "Failed to find target"

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ test:
 	$(info TEST_OPTS: $(TEST_OPTS))
 	$(info log-file: test-$(TEST_SUFFIX).log)
 	$(TEST_OPTS) ./test.sh 2>&1 | tee test-$(TEST_SUFFIX).log
-	! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-$(TEST_SUFFIX).log
+	! egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-$(TEST_SUFFIX).log
 
 test-smoke:
 	$(info log-file: test-$(TEST_SUFFIX).log)
@@ -174,7 +174,7 @@ docker-test:
 	  --mount type=bind,source=`pwd`,destination=/go/src/go.etcd.io/etcd \
 	  gcr.io/etcd-development/etcd-test:go$(GO_VERSION) \
 	  /bin/bash -c "$(TEST_OPTS) ./test.sh 2>&1 | tee test-$(TEST_SUFFIX).log"
-	! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-$(TEST_SUFFIX).log
+	! egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-$(TEST_SUFFIX).log
 
 docker-test-coverage:
 	$(info GO_VERSION: $(GO_VERSION))
@@ -188,7 +188,7 @@ docker-test-coverage:
 	  --mount type=bind,source=`pwd`,destination=/go/src/go.etcd.io/etcd \
 	  gcr.io/etcd-development/etcd-test:go$(GO_VERSION) \
 	  /bin/bash ./scripts/codecov_upload.sh docker-test-coverage-$(TEST_SUFFIX).log \
-	! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 docker-test-coverage-$(TEST_SUFFIX).log
+	! egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 docker-test-coverage-$(TEST_SUFFIX).log
 
 
 


### PR DESCRIPTION
add 'FAIL:' to egrep for cover some test log.
The effect is as follows:
```shell
[root@LF-136-9 etcd]# egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-MTYyNjIyOTc0MQo.log
[root@LF-136-9 etcd]# egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-MTYyNjIyOTc0MQo.log
ok    go.etcd.io/etcd/server/v3/auth  3.247s
ok    go.etcd.io/etcd/server/v3/config  0.047s
ok    go.etcd.io/etcd/server/v3/datadir 0.035s
ok    go.etcd.io/etcd/server/v3/embed 1.944s
ok    go.etcd.io/etcd/server/v3/etcdmain  0.326s
FAIL  go.etcd.io/etcd/server/v3/etcdserver [build failed]
?     go.etcd.io/etcd/server/v3/etcdserver/api  [no test files]
ok    go.etcd.io/etcd/server/v3/etcdserver/api/etcdhttp 0.110s
ok    go.etcd.io/etcd/server/v3/etcdserver/api/membership 0.479s
ok    go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp 0.251s
ok    go.etcd.io/etcd/server/v3/etcdserver/api/snap 0.045s
?     go.etcd.io/etcd/server/v3/etcdserver/api/snap/snappb  [no test files]
ok    go.etcd.io/etcd/server/v3/etcdserver/api/v2auth 1.470s
ok    go.etcd.io/etcd/server/v3/etcdserver/api/v2discovery  0.088s
ok    go.etcd.io/etcd/server/v3/etcdserver/api/v2error  0.034s
ok    go.etcd.io/etcd/server/v3/etcdserver/api/v2http 0.128s
ok    go.etcd.io/etcd/server/v3/etcdserver/api/v2http/httptypes 0.033s
?     go.etcd.io/etcd/server/v3/etcdserver/api/v2stats  [no test files]
ok    go.etcd.io/etcd/server/v3/etcdserver/api/v2store  0.068s
?     go.etcd.io/etcd/server/v3/etcdserver/api/v2v3 [no test files]
?     go.etcd.io/etcd/server/v3/etcdserver/api/v3alarm  [no test files]
?     go.etcd.io/etcd/server/v3/etcdserver/api/v3client [no test files]
ok    go.etcd.io/etcd/server/v3/etcdserver/api/v3compactor  1.793s
?     go.etcd.io/etcd/server/v3/etcdserver/api/v3election [no test files]
?     go.etcd.io/etcd/server/v3/etcdserver/api/v3election/v3electionpb  [no test files]
?     go.etcd.io/etcd/server/v3/etcdserver/api/v3election/v3electionpb/gw [no test files]
?     go.etcd.io/etcd/server/v3/etcdserver/api/v3lock [no test files]
?     go.etcd.io/etcd/server/v3/etcdserver/api/v3lock/v3lockpb  [no test files]
?     go.etcd.io/etcd/server/v3/etcdserver/api/v3lock/v3lockpb/gw [no test files]
ok    go.etcd.io/etcd/server/v3/etcdserver/api/v3rpc  0.089s
ok    go.etcd.io/etcd/server/v3/etcdserver/cindex 0.045s
ok    go.etcd.io/etcd/server/v3/lease 3.324s
ok    go.etcd.io/etcd/server/v3/lease/leasehttp 2.096s
?     go.etcd.io/etcd/server/v3/lease/leasepb [no test files]
?     go.etcd.io/etcd/server/v3/mock/mockstorage  [no test files]
?     go.etcd.io/etcd/server/v3/mock/mockstore  [no test files]
?     go.etcd.io/etcd/server/v3/mock/mockwait [no test files]
ok    go.etcd.io/etcd/server/v3/mvcc  8.805s
ok    go.etcd.io/etcd/server/v3/mvcc/backend  1.983s
?     go.etcd.io/etcd/server/v3/mvcc/backend/testing  [no test files]
?     go.etcd.io/etcd/server/v3/mvcc/buckets  [no test files]
?     go.etcd.io/etcd/server/v3/proxy/grpcproxy [no test files]
?     go.etcd.io/etcd/server/v3/proxy/grpcproxy/adapter [no test files]
?     go.etcd.io/etcd/server/v3/proxy/grpcproxy/cache [no test files]
ok    go.etcd.io/etcd/server/v3/proxy/httpproxy 0.046s
ok    go.etcd.io/etcd/server/v3/proxy/tcpproxy  0.035s
?     go.etcd.io/etcd/server/v3/verify  [no test files]
ok    go.etcd.io/etcd/server/v3/wal 0.513s
ok    go.etcd.io/etcd/server/v3/wal/walpb 0.045s
FAIL
FAIL: (code:2):
  % (cd server && env go test -short -timeout=3m --race --cpu=16 ./...)
FAIL: 'unit' failed at Wed Jul 14 10:29:37 CST 2021
```
